### PR TITLE
Manage locale configuration only when pillar settings are present

### DIFF
--- a/locale/init.sls
+++ b/locale/init.sls
@@ -27,11 +27,9 @@ locale_default:
 {% endif %}
 
 {%- set conf = salt['pillar.get']('locale:conf', {}) %}
-{%- if conf is iterable %}
+{%- if conf %}
 locale-conf-is-setup:
   file.managed:
     - name: /etc/locale.conf
     - contents_pillar: locale:conf
-{% else %}
 {% endif %}
-


### PR DESCRIPTION
The current logic will try to render /etc/locale.conf even if 'locale:conf' is
undefined as an empty dictionary is iterable.