### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/default.sls test/salt/pillar/fedora.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/locale/defaults.yaml
+++ b/locale/defaults.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 locale:
   config: '/etc/locale.conf'
   pkgs: []

--- a/pillar.example
+++ b/pillar.example
@@ -1,13 +1,15 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 locale:
   present:
     - "en_US.UTF-8 UTF-8"
     - "de_DE.UTF-8 UTF-8"
-  default: 
-    name: 'en_US.UTF-8' # Note: On debian systems don't write the 
-                        # second 'UTF-8' here or you will experience 
-                        # salt problems like:
-                        # LookupError: unknown encoding: utf_8_utf_8
-                        # Restart the minion after you corrected this!
+  default:
+    # Note: On debian systems don't write the second 'UTF-8' here or you will
+    # experience salt problems like: LookupError: unknown encoding: utf_8_utf_8
+    # Restart the minion after you corrected this!
+    name: 'en_US.UTF-8'
     requires: 'en_US.UTF-8 UTF-8'
   # You can manipulate the contents of /etc/locale.conf, e.g.
   conf:

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: locale formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 locale:
   present:
     - "en_US.UTF-8 UTF-8"

--- a/test/salt/pillar/fedora.sls
+++ b/test/salt/pillar/fedora.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 locale:
   pkgs:
     - glibc-langpack-de


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
locale-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./locale/defaults.yaml
  1:1       warning  missing document start "---"  (document-start)

pillar.example
  1:1       warning  missing document start "---"  (document-start)
  5:11      error    trailing spaces  (trailing-spaces)
  6:25      warning  too few spaces before comment  (comments)
  6:66      error    trailing spaces  (trailing-spaces)
  7:25      warning  comment not indented like content  (comments-indentation)
  7:69      error    trailing spaces  (trailing-spaces)

test/salt/pillar/default.sls
  1:1       warning  missing document start "---"  (document-start)

test/salt/pillar/fedora.sls
  1:1       warning  missing document start "---"  (document-start)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.